### PR TITLE
Use tracemalloc instead of memory_profiler.

### DIFF
--- a/examples/04_dimension_reduction_and_performance.py
+++ b/examples/04_dimension_reduction_and_performance.py
@@ -31,15 +31,11 @@ def resource_used(func):
     def wrapped_func(*args, **kwargs):
         t0 = time()
         tracemalloc.start()
-
         out = func(*args, **kwargs)
-
         size, peak = tracemalloc.get_traced_memory()
         tracemalloc.stop()
         peak /= (1024 ** 2)  # Converts to megabytes
-
         print(f"Run time: {time() - t0}s    Memory used: {peak}MB")
-
         return out
 
     return wrapped_func


### PR DESCRIPTION
Use Python built-in ``tracemalloc`` instead of ``memory_profiler``.
This is the same thing as the previous commit, except this should fix the visualization.